### PR TITLE
Handle "REPAIRING" cluster state

### DIFF
--- a/pkg/broker/instance_operations.go
+++ b/pkg/broker/instance_operations.go
@@ -392,8 +392,9 @@ func (b Broker) LastOperation(ctx context.Context, instanceID string, details do
 		// Provision has succeeded if the cluster is in state "idle".
 		case "IDLE":
 			resp.State = domain.Succeeded
-		case "CREATING", "UPDATING":
+		case "CREATING", "UPDATING", "REPAIRING":
 			resp.State = domain.InProgress
+			resp.Description = cluster.StateName
 		default:
 			resp.Description = fmt.Sprintf("unknown cluster state %q", cluster.StateName)
 		}


### PR DESCRIPTION
The `REPAIRING` Cluster state was not properly handled by the broker which caused `Update()` to fail in some cases. This PR fixes the issue by mapping this Cluster state to the `update in progress` Broker state.