### PR TITLE
Allow Deprovision() to proceed even if the Cluster failed to delete

### DIFF
--- a/pkg/broker/broker.go
+++ b/pkg/broker/broker.go
@@ -95,7 +95,7 @@ func (b *Broker) funcLogger() *zap.SugaredLogger {
 }
 
 func (b *Broker) parsePlan(ctx dynamicplans.Context, planID string) (dp *dynamicplans.Plan, err error) {
-	logger := b.funcLogger()
+	logger := b.funcLogger().With("plan_id", planID)
 	sp, ok := b.catalog.plans[planID]
 	if !ok {
 		err = fmt.Errorf("plan ID %q not found in catalog", planID)
@@ -104,7 +104,7 @@ func (b *Broker) parsePlan(ctx dynamicplans.Context, planID string) (dp *dynamic
 
 	tpl, ok := sp.Metadata.AdditionalMetadata["template"].(dynamicplans.TemplateContainer)
 	if !ok {
-		err = errors.New("plan ID %q does not contain a valid plan template")
+		err = fmt.Errorf("plan ID %q does not contain a valid plan template", planID)
 		return
 	}
 

--- a/pkg/broker/instance_operations.go
+++ b/pkg/broker/instance_operations.go
@@ -40,9 +40,9 @@ const (
 // Provision will create a new Atlas cluster with the instance ID as its name.
 // The process is always async.
 func (b Broker) Provision(ctx context.Context, instanceID string, details domain.ProvisionDetails, asyncAllowed bool) (spec domain.ProvisionedServiceSpec, err error) {
-	logger := b.funcLogger()
+	logger := b.funcLogger().With("instance_id", instanceID)
 
-	logger.Infow("Provisioning instance", "instance_id", instanceID, "details", details)
+	logger.Infow("Provisioning instance", "details", details)
 
 	planContext := dynamicplans.Context{
 		"instance_id": instanceID,
@@ -124,7 +124,7 @@ func (b Broker) Provision(ctx context.Context, instanceID string, details domain
 		return
 	}
 
-	logger.Infow("Successfully started Atlas creation process", "instance_id", instanceID, "cluster", resultingCluster)
+	logger.Infow("Successfully started Atlas creation process", "cluster", resultingCluster)
 
 	return domain.ProvisionedServiceSpec{
 		IsAsync:       true,
@@ -161,8 +161,8 @@ func (b *Broker) createResources(ctx context.Context, client *mongodbatlas.Clien
 
 // Update will change the configuration of an existing Atlas cluster asynchronously.
 func (b Broker) Update(ctx context.Context, instanceID string, details domain.UpdateDetails, asyncAllowed bool) (spec domain.UpdateServiceSpec, err error) {
-	logger := b.funcLogger()
-	logger.Infow("Updating instance", "instance_id", instanceID, "details", details)
+	logger := b.funcLogger().With("instance_id", instanceID)
+	logger.Infow("Updating instance", "details", details)
 
 	planContext := dynamicplans.Context{
 		"instance_id": instanceID,
@@ -252,19 +252,19 @@ func (b Broker) Update(ctx context.Context, instanceID string, details domain.Up
 	// TODO: make this error-out reversible?
 	err = state.DeleteOne(ctx, instanceID)
 	if err != nil {
-		logger.Errorw("Error delete from state", "err", err, "instanceID", instanceID)
+		logger.Errorw("Error delete from state", "err", err)
 		return
 	}
 
 	obj, err := state.Put(ctx, instanceID, &s)
 	if err != nil {
-		logger.Errorw("Error insert one from state", "err", err, "instanceID", instanceID, "s", s)
+		logger.Errorw("Error insert one from state", "err", err, "s", s)
 		return
 	}
 	//
 	//s, err := b.state.UpdateOne(instanceID,
 	logger.Infow("Inserted into state", "obj", obj)
-	logger.Infow("Successfully started Atlas cluster update process", "instance_id", instanceID, "cluster", resultingCluster)
+	logger.Infow("Successfully started Atlas cluster update process", "cluster", resultingCluster)
 
 	return domain.UpdateServiceSpec{
 		IsAsync:       true,
@@ -275,8 +275,8 @@ func (b Broker) Update(ctx context.Context, instanceID string, details domain.Up
 
 // Deprovision will destroy an Atlas cluster asynchronously.
 func (b Broker) Deprovision(ctx context.Context, instanceID string, details domain.DeprovisionDetails, asyncAllowed bool) (spec domain.DeprovisionServiceSpec, err error) {
-	logger := b.funcLogger()
-	logger.Infow("Deprovisioning instance", "instance_id", instanceID, "details", details)
+	logger := b.funcLogger().With("instance_id", instanceID)
+	logger.Infow("Deprovisioning instance", "details", details)
 
 	client, p, err := b.getClient(ctx, instanceID, details.PlanID, nil)
 	if err != nil {
@@ -291,7 +291,7 @@ func (b Broker) Deprovision(ctx context.Context, instanceID string, details doma
 
 	_, err = client.Clusters.Delete(ctx, p.Project.ID, p.Cluster.Name)
 	if err != nil {
-		logger.Errorw("Failed to delete Atlas cluster", "error", err, "instance_id", instanceID)
+		logger.Errorw("Failed to delete Atlas cluster", "error", err)
 		return
 	}
 
@@ -302,7 +302,7 @@ func (b Broker) Deprovision(ctx context.Context, instanceID string, details doma
 		}
 	}
 
-	logger.Infow("Successfully started Atlas cluster deletion process", "instance_id", instanceID)
+	logger.Infow("Successfully started Atlas Cluster & Project deletion process")
 
 	return domain.DeprovisionServiceSpec{
 		IsAsync:       true,
@@ -352,8 +352,8 @@ func (b Broker) getInstance(ctx context.Context, instanceID string) (spec domain
 // LastOperation should fetch the state of the provision/deprovision
 // of a cluster.
 func (b Broker) LastOperation(ctx context.Context, instanceID string, details domain.PollDetails) (resp domain.LastOperation, err error) {
-	logger := b.funcLogger()
-	logger.Infow("Fetching state of last operation", "instance_id", instanceID, "details", details)
+	logger := b.funcLogger().With("instance_id", instanceID)
+	logger.Infow("Fetching state of last operation", "details", details)
 
 	resp.State = domain.Failed
 
@@ -374,7 +374,7 @@ func (b Broker) LastOperation(ctx context.Context, instanceID string, details do
 	cluster, r, err := client.Clusters.Get(ctx, p.Project.ID, p.Cluster.Name)
 	if err != nil && r.StatusCode != http.StatusNotFound {
 		err = errors.Wrap(err, "cannot get existing cluster")
-		logger.Errorw("Failed to get existing cluster", "error", err, "instance_id", instanceID)
+		logger.Errorw("Failed to get existing cluster", "error", err)
 		return
 	}
 

--- a/pkg/broker/instance_operations.go
+++ b/pkg/broker/instance_operations.go
@@ -292,7 +292,6 @@ func (b Broker) Deprovision(ctx context.Context, instanceID string, details doma
 	_, err = client.Clusters.Delete(ctx, p.Project.ID, p.Cluster.Name)
 	if err != nil {
 		logger.Errorw("Failed to delete Atlas cluster", "error", err)
-		return
 	}
 
 	for _, u := range p.DatabaseUsers {
@@ -417,6 +416,7 @@ func (b Broker) LastOperation(ctx context.Context, instanceID string, details do
 					"projectID", p.Project.ID,
 					"projectName", p.Project.Name,
 				)
+				break
 			}
 
 			state, errDel := b.getState(p.Project.OrgID)


### PR DESCRIPTION
This will prevent the user from getting instances stuck in `delete failed` state if, for any reason, their Cluster is missing in Atlas. The Deprovision will still fail at a later stage if it fails to delete the Project

Prevents #9 from occurring in the future

(Also, broker logs have been improved slightly)