### PR TITLE
Add default User Scope

### DIFF
--- a/pkg/broker/binding_operations.go
+++ b/pkg/broker/binding_operations.go
@@ -232,6 +232,13 @@ func (b *Broker) userFromParams(bindingID string, password string, rawParams []b
 		params.User.DatabaseName = "admin"
 	}
 
+	if len(params.User.Scopes) == 0 {
+		params.User.Scopes = append(params.User.Scopes, mongodbatlas.Scope{
+			Name: plan.Cluster.Name,
+			Type: "CLUSTER",
+		})
+	}
+
 	logger.Debugw("userFromParams", "params", params)
 
 	// If no role is specified we default to read/write on any database.

--- a/pkg/broker/instance_operations.go
+++ b/pkg/broker/instance_operations.go
@@ -143,6 +143,13 @@ func (b *Broker) createResources(ctx context.Context, client *mongodbatlas.Clien
 	}
 
 	for _, u := range dp.DatabaseUsers {
+		if len(u.Scopes) == 0 {
+			u.Scopes = append(u.Scopes, mongodbatlas.Scope{
+				Name: dp.Cluster.Name,
+				Type: "CLUSTER",
+			})
+		}
+
 		_, _, err := client.DatabaseUsers.Create(ctx, p.ID, u)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
This PR adds a default Scope to the Binding user and Plan's DatabaseUser if no scopes are explicitly passed.

Fixes #38 