### PR TITLE
Fix /v2/service_instances/#/parameters error

### DIFF
--- a/pkg/broker/instance_operations.go
+++ b/pkg/broker/instance_operations.go
@@ -361,6 +361,14 @@ func (b Broker) GetInstance(ctx context.Context, instanceID string) (spec domain
 		return spec, apiresponses.NewFailureResponse(err, http.StatusInternalServerError, "get-instance")
 	}
 
+	if enc, ok := spec.Parameters.(string); ok {
+		p, err := decodePlan(enc)
+		if err != nil {
+			return spec, apiresponses.NewFailureResponse(err, http.StatusInternalServerError, "get-instance")
+		}
+		spec.Parameters = p.SafeCopy()
+	}
+
 	return spec, nil
 }
 


### PR DESCRIPTION
Fixes #63 

As it turned out, CF's `/parameters` endpoint requires `parameters` to contain an `object`, not a `string` - this PR addresses that issue