### PR TITLE
Make API errors non-fatal

### DIFF
--- a/pkg/broker/instance_operations.go
+++ b/pkg/broker/instance_operations.go
@@ -400,15 +400,6 @@ func (b Broker) LastOperation(ctx context.Context, instanceID string, details do
 
 	resp.State = domain.Failed
 
-	// brokerapi will NOT update service state if we return any error, so... we won't?
-	defer func() {
-		if err != nil {
-			resp.State = domain.Failed
-			resp.Description = "got error: " + err.Error()
-			err = nil
-		}
-	}()
-
 	client, p, err := b.getClient(ctx, instanceID, details.PlanID, nil)
 	if err != nil {
 		return
@@ -423,6 +414,15 @@ func (b Broker) LastOperation(ctx context.Context, instanceID string, details do
 	}
 
 	logger.Infow("Found existing cluster", "cluster", cluster)
+
+	// brokerapi will NOT update service state if we return any error, so... we won't?
+	defer func() {
+		if err != nil {
+			resp.State = domain.Failed
+			resp.Description = "got error: " + err.Error()
+			err = nil
+		}
+	}()
 
 	switch details.OperationData {
 	case operationProvision, operationUpdate:


### PR DESCRIPTION
Make API errors non-fatal to avoid failing instance creation in case of an intermittent API/network failure.

One side effect of this would be that it's now possible to get instances stuck in "in progress" on OSB side by removing API keys from credentials while the instance is still creating - however this is much less common than what this PR is intended to fix.

Fixes #68 