### PR TITLE
Remove PE name check from delete function

### DIFF
--- a/pkg/broker/instance_operations.go
+++ b/pkg/broker/instance_operations.go
@@ -250,10 +250,8 @@ func (b Broker) deletePrivateEndpoint(ctx context.Context, client *mongodbatlas.
 	logger := b.funcLogger()
 
 	for _, endpoint := range plan.PrivateEndpoints {
-		if endpoint.EndpointName == peConnection.EndpointServiceName && endpoint.Provider == peConnection.ProviderName {
-			if _, err := privateendpoint.Delete(ctx, endpoint); err != nil {
-				logger.Errorw("Failed to delete Private Endpoint from Azure", "error", err, "endpoint", endpoint.EndpointName)
-			}
+		if _, err := privateendpoint.Delete(ctx, endpoint); err != nil {
+			logger.Errorw("Failed to delete Private Endpoint from Azure", "error", err, "endpoint", endpoint.EndpointName)
 		}
 	}
 


### PR DESCRIPTION
There is no reason to check PE inside of delete function.
This fixes cases where endpoint wasn't deleted on Azure side and left in the Disconnected state.