### PR TITLE
Support service updates through scheme

### DIFF
--- a/.github/workflows/deploy-broker.yml
+++ b/.github/workflows/deploy-broker.yml
@@ -51,7 +51,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        plan: ["override-bind-db-plan", "multiregion-override-bind-db-plan"]
+        include:
+          - plan: "override-bind-db-plan"
+            update: "{\"instance_size\":\"M20\"}"
+          - plan: "multiregion-override-bind-db-plan"
+            update: "{\"instance_size\":\"M20\"}"
+          - plan: "override-bind-db-plan"
+            update: "{\"cluster\":{\"providerSettings\":{\"instanceSizeName\":\"M20\"}}}"
     steps:
       - uses: actions/checkout@v2.3.1
 
@@ -84,6 +90,7 @@ jobs:
           atlas_org_id: ${{ secrets.ATLAS_ORG_ID }}
         env:
           TEST_PLAN: ${{ matrix.plan }}
+          TEST_UPDATE_TYPE: ${{ matrix.update }}
           TEST_TYPE: "go"
 
       - name: Upload operator logs

--- a/pkg/broker/dynamicplans/plan.go
+++ b/pkg/broker/dynamicplans/plan.go
@@ -16,7 +16,6 @@ package dynamicplans
 
 import (
 	"encoding/json"
-	"fmt"
 
 	"github.com/mongodb/atlas-osb/pkg/broker/credentials"
 	"github.com/mongodb/atlas-osb/pkg/broker/privateendpoint"
@@ -75,24 +74,4 @@ func (p Plan) String() string {
 	}
 
 	return string(s)
-}
-
-func (p *Plan) UnmarshalJSON(data []byte) error {
-	type plan Plan
-
-	var pl plan
-	err := json.Unmarshal(data, &pl)
-
-	// try to fix the plan in case of an error
-	if err != nil && pl.APIKey != nil {
-		if pl.Project.OrgID == "" {
-			return fmt.Errorf("failed to fix the plan with error: %w", err)
-		}
-
-		pl.APIKey["orgID"] = pl.Project.OrgID
-	}
-
-	*p = Plan(pl)
-
-	return nil
 }

--- a/pkg/broker/instance_operations.go
+++ b/pkg/broker/instance_operations.go
@@ -250,10 +250,8 @@ func (b Broker) deletePrivateEndpoint(ctx context.Context, client *mongodbatlas.
 	logger := b.funcLogger()
 
 	for _, endpoint := range plan.PrivateEndpoints {
-		if endpoint.EndpointName == peConnection.EndpointServiceName && endpoint.Provider == peConnection.ProviderName {
-			if _, err := privateendpoint.Delete(ctx, endpoint); err != nil {
-				logger.Errorw("Failed to delete Private Endpoint from Azure", "error", err, "endpoint", endpoint.EndpointName)
-			}
+		if _, err := privateendpoint.Delete(ctx, endpoint); err != nil {
+			logger.Errorw("Failed to delete Private Endpoint from Azure", "error", err, "endpoint", endpoint.EndpointName)
 		}
 	}
 

--- a/test/cfe2e/c_test.go
+++ b/test/cfe2e/c_test.go
@@ -129,7 +129,7 @@ var _ = Describe("Feature: Atlas broker supports basic template", func() {
 			})
 			By("Can scale cluster size", func() {
 				newSize := "M20"
-				Eventually(cfc.Cf("update-service", testData.ServiceIns, "-c", "{\"instance_size\":\"M20\"}")).Should(Say("OK"))
+				Eventually(cfc.Cf("update-service", testData.ServiceIns, "-c", testData.UpdateType)).Should(Say("OK"))
 				waitServiceStatus(testData.ServiceIns, "update succeeded")
 
 				// get the real size

--- a/test/cfe2e/model/test/test.go
+++ b/test/cfe2e/model/test/test.go
@@ -18,6 +18,7 @@ type Test struct {
 	ServiceIns string
 	TestApp    string
 	PlanName   string
+	UpdateType string
 }
 
 func NewTest() Test {
@@ -33,5 +34,6 @@ func NewTest() Test {
 	test.TestApp = os.Getenv("TEST_SIMPLE_APP") + id
 	test.PlanName = os.Getenv("TEST_PLAN")
 	test.APIKeys = atlaskey.NewAtlasKeys()
+	test.UpdateType = os.Getenv("TEST_UPDATE_TYPE")
 	return test
 }


### PR DESCRIPTION
Bring back the support for `-c` service updates like these:
```bash
cf update-service <instance_name> -c '{"cluster":{"providerSettings":{"instanceSizeName":"M20"}}}'
```